### PR TITLE
Fix RemovedInDjango110Warning

### DIFF
--- a/pinax/images/urls.py
+++ b/pinax/images/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import (
     images,
@@ -8,11 +8,10 @@ from .views import (
 )
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^sets/new/upload/$", images_upload, name="images_set_new_upload"),
     url(r"^sets/(?P<pk>\d+)/upload/$", images_upload, name="images_set_upload"),
     url(r"^sets/(?P<pk>\d+)/$", images, name="images"),
     url(r"^(?P<pk>\d+)/delete/$", images_delete, name="images_delete"),
     url(r"^(?P<pk>\d+)/make-primary/$", images_make_primary, name="images_make_primary"),
-)
+]


### PR DESCRIPTION
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

Just replace patterns with a []
