### PR TITLE
Add "created_by" in admin inline fields

### DIFF
--- a/pinax/images/admin.py
+++ b/pinax/images/admin.py
@@ -5,7 +5,7 @@ from .models import ImageSet, Image
 
 class ImageInline(admin.TabularInline):
     model = Image
-    fields = ["image", "preview"]
+    fields = ["image", "created_by", "preview"]
     readonly_fields = ["preview"]
 
     def preview(self, obj):


### PR DESCRIPTION
Image couldn't be added via django admin, simply add "created_by" in inlines fields to make it working.
