### PR TITLE
Remove Django "master" from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ python:
 env:
   - DJANGO=1.8
   - DJANGO=1.9
-  - DJANGO=master
+  - DJANGO=1.10
 matrix:
   exclude:
     - python: "3.3"
       env: DJANGO=1.9
     - python: "3.3"
-      env: DJANGO=master
+      env: DJANGO=1.10
 install:
   - pip install tox coveralls
 script:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.1
+
+* Update test matrix to include Django 1.10 and exclude Django dev branch
+
 ## 2.0.0
 
 * Revise access permissions for some views:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,8 @@ Refer to [Usage](./usage.md) for adding image collection functionality to your a
 * `django-appconf>=1.0.1`
 * `django-imagekit>=3.2.7`
 * `pilkit>=1.1.13`
-* `pillow>=3.0`
-* `pytz>=2015.6`
+* `pillow>=3.4.2`
+* `pytz>=2016.6.1`
 
 ## Changelog
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="an app for managing collections of images associated with a content object",
     name="pinax-images",
     long_description=read("README.md"),
-    version="2.0.0",
+    version="2.0.1",
     url="http://github.com/pinax/pinax-images/",
     license="MIT",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,14 @@ setup(
     },
     test_suite="runtests.runtests",
     tests_require=[
-        "django-test-plus>=1.0.11",
+        "django-test-plus>=1.0.17",
         "mock>=2.0.0",
     ],
     install_requires=[
         "django-appconf>=1.0.1",
         "django-imagekit>=3.2.7",
         "pilkit>=1.1.13",
-        "pillow>=3.3.0",
+        "pillow>=3.4.2",
         "pytz>=2016.6.1",
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.9,master},
+    py27-{1.8,1.9,1.10},
     py33-{1.8},
-    py34-{1.8,1.9,master},
-    py35-{1.8,1.9,master}
+    py34-{1.8,1.9,1.10},
+    py35-{1.8,1.9,1.10}
 
 [testenv]
 deps =
@@ -17,7 +17,7 @@ deps =
     flake8 == 2.5.0
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
-    master: https://github.com/django/django/tarball/master
+    1.10: Django>=1.10,<1.11
 usedevelop = True
 setenv =
    LANG=en_US.UTF-8


### PR DESCRIPTION
Include Django v1.10 in test matrix.
Also updates to new minor version release of Pillow.