### PR TITLE
Use format_html() to escape html tags in admin preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ PINAX_IMAGES_THUMBNAIL_SPEC = "{{my_app}}.specs.MyCustomImageThumbnail"
 
 ## Change Log
 
+### 3.0.2
+
+* Use format_html() to escape html tags in admin preview
+
 ### 3.0.1
 
 * Standardize documentation, badges

--- a/pinax/images/admin.py
+++ b/pinax/images/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from .models import Image, ImageSet
 
@@ -10,7 +11,9 @@ class ImageInline(admin.TabularInline):
 
     def preview(self, obj):
         if obj.pk:
-            return "<img src='{}' />".format(obj.small_thumbnail.url)
+            return format_html(
+                "<img src='{}' />".format(obj.small_thumbnail.url)
+            )
         return "Upload image for preview"
     preview.allow_tags = True
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "3.0.1"
+VERSION = "3.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-images.svg
     :target: https://pypi.python.org/pypi/pinax-images/


### PR DESCRIPTION
Fixes #25